### PR TITLE
Adding MD4C

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -170,5 +170,19 @@
     "Lang": "C#",
     "Repo": "https://github.com/lunet-io/markdig/",
     "CommonMark": "true"
+  },
+  {
+    "Name": "MD4C",
+    "Url": "http://morous.org/md4c/babel.php",
+    "Lang": "C",
+    "Repo": "https://github.com/mity/md4c",
+    "CommonMark": "true"
+  },
+  {
+    "Name": "MD4C (strict)",
+    "Url": "http://morous.org/md4c/babel-strict.php",
+    "Lang": "C",
+    "Repo": "https://github.com/mity/md4c",
+    "CommonMark": "true"
   }
 ]


### PR DESCRIPTION
MD4C is new C Markdown parser implementation.

See http://github.com/mity/md4c and https://talk.commonmark.org/t/md4c-new-implementation-in-c/2302 for more info about the project.

Two records are added:
 - "MD4C (strict)" is in strict CommonMark compatibility mode.
 - "MD4C" has some extensions enabled: Tables and permissive autolinks (without enclosing `<`, `>`).