### PR TITLE
Add pulldown-cmark

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -215,5 +215,12 @@
     "Url": "https://blogdown.io/api/babelmark",
     "Lang": "Haskell",
     "Repo": "https://github.com/alexbecker/blogdown"
+  },
+  {
+    "Name": "pulldown-cmark",
+    "Url": "https://www.xfix.pw/api/babelmark/pulldown-cmark",
+    "Lang": "Rust",
+    "Repo": "https://github.com/raphlinus/pulldown-cmark",
+    "CommonMark": "true"
   }
 ]


### PR DESCRIPTION
The URL is not encrypted, as I'm not concerned about attacks, in fact attacks are appreciated to improve the security of my service using pulldown-cmark, https://pastebin.run/.