### PR TITLE
Update Rust dinguses

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -228,7 +228,7 @@
     "Url": "https://dingus.passcod.nz/mini_markdown",
     "CommonMark": "false",
     "Repo": "https://github.com/darakian/mini_markdown"
-  }
+  },
   {
     "Lang": "Kotlin",
     "Name": "intellij-markdown (commonmark)",

--- a/registry.json
+++ b/registry.json
@@ -176,59 +176,59 @@
   {
     "Lang": "Rust",
     "Name": "pulldown-cmark",
-    "Url": "https://markdown-dingus-ezo7.shuttle.app/pulldown-cmark",
+    "Url": "https://dingus.passcod.nz/pulldown-cmark",
     "CommonMark": "true",
     "Repo": "https://github.com/pulldown-cmark/pulldown-cmark"
   },
   {
     "Lang": "Rust",
     "Name": "markdown",
-    "Url": "https://markdown-dingus-ezo7.shuttle.app/markdown",
+    "Url": "https://dingus.passcod.nz/markdown",
     "CommonMark": "true",
     "Repo": "https://github.com/wooorm/markdown-rs"
   },
   {
     "Lang": "Rust",
     "Name": "comrak",
-    "Url": "https://markdown-dingus-ezo7.shuttle.app/comrak",
+    "Url": "https://dingus.passcod.nz/comrak",
     "CommonMark": "true",
     "Repo": "https://github.com/kivikakk/comrak"
   },
   {
     "Lang": "Rust",
     "Name": "markdown-it",
-    "Url": "https://markdown-dingus-ezo7.shuttle.app/markdown-it",
+    "Url": "https://dingus.passcod.nz/markdown-it",
     "CommonMark": "true",
     "Repo": "https://github.com/markdown-it-rust/markdown-it"
   },
   {
     "Lang": "Rust",
     "Name": "markdowny",
-    "Url": "https://markdown-dingus-ezo7.shuttle.app/markdowny",
+    "Url": "https://dingus.passcod.nz/markdowny",
     "CommonMark": "false",
     "Repo": "https://gitlab.com/bitpowder/indigo-ng"
   },
   {
     "Lang": "Rust",
     "Name": "concisemark",
-    "Url": "https://markdown-dingus-ezo7.shuttle.app/concisemark",
+    "Url": "https://dingus.passcod.nz/concisemark",
     "CommonMark": "false",
     "Repo": "https://github.com/ikey4u/concisemark"
   },
   {
     "Lang": "Rust",
     "Name": "mdxt",
-    "Url": "https://markdown-dingus-ezo7.shuttle.app/mdxt",
+    "Url": "https://dingus.passcod.nz/mdxt",
     "CommonMark": "false",
     "Repo": "https://github.com/baehyunsol/mdxt"
   },
   {
     "Lang": "Rust",
     "Name": "mini_markdown",
-    "Url": "https://markdown-dingus-ezo7.shuttle.app/mini_markdown",
+    "Url": "https://dingus.passcod.nz/mini_markdown",
     "CommonMark": "false",
     "Repo": "https://github.com/darakian/mini_markdown"
-  },
+  }
   {
     "Lang": "Kotlin",
     "Name": "intellij-markdown (commonmark)",


### PR DESCRIPTION
Fixes #27

This puts them at a URL I control so I can stop bothering your if/when the host changes. Also these are hosted at a paid instance of fly.io so should be solid.